### PR TITLE
chore: remove stray mcp_curl_test.txt

### DIFF
--- a/mcp_curl_test.txt
+++ b/mcp_curl_test.txt
@@ -1,1 +1,0 @@
-Test by curl


### PR DESCRIPTION
This PR deletes an obsolete test file `mcp_curl_test.txt` from the repo root.